### PR TITLE
Replace link to malicious website

### DIFF
--- a/cose-base.js
+++ b/cose-base.js
@@ -313,7 +313,8 @@ CoSELayout.prototype.tick = function () {
       this.coolingAdjuster = this.coolingCycle / 3;
     }
 
-    // cooling schedule is based on http://www.btluke.com/simanf1.html -> cooling schedule 3
+    // cooling schedule is based on https://web.archive.org/web/20190620071317/http:/www.------btluke------.com/simanf1.html -> cooling schedule 3
+    //                              Caution: Only visit the archived site and these are  ^^^^^^      ^^^^^^ placeholders against antivirus false positives.
     this.coolingFactor = Math.max(this.initialCoolingFactor - Math.pow(this.coolingCycle, Math.log(100 * (this.initialCoolingFactor - this.finalTemperature)) / Math.log(this.maxCoolingCycle)) / 100 * this.coolingAdjuster, this.finalTemperature);
     this.animationPeriod = Math.ceil(this.initialAnimationPeriod * Math.sqrt(this.coolingFactor));
   }


### PR DESCRIPTION
Our antivirus flagged this JavaScript file because a comment linked to a malicious website.

See https://github.com/jupyter/notebook/security/advisories/GHSA-7g38-vjhf-p79j#advisory-comment-177402

Closes https://github.com/jupyter/notebook/security/advisories/GHSA-7g38-vjhf-p79j.

@hasanbalci would you mind creating a new release?
